### PR TITLE
feat: Implement Gemini 1.5 Pro/Flash APIs and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,97 @@
 # Common Lisp library to access Google Gemini LLM APIs
 
-From my book URI: https://leanpub.com/lovinglisp
+This library provides a Common Lisp interface to Google's Gemini Large Language Models. It supports various models like Gemini 1.5 Pro and Gemini 1.5 Flash, and offers functionalities including text generation, token counting, chat conversations, and streaming responses.
 
-There is a **Makefile** in the repo https://github.com/mark-watson/loving-common-lisp that can be copied
-to your **~/quicklisp/local-projects** directory. Then in **~/quicklisp/local-projects** run:
+This project was originally forked from a library for Perplexity AI in the book [Loving Common Lisp](https://leanpub.com/lovinglisp) by Mark Watson.
 
-    make fetch
+## Setting your GOOGLE_API_KEY API key
 
-to get all of the library examples from my book.
+Define the `GOOGLE_API_KEY` environment variable with the value of your Google API key. You can obtain an API key from the [Google AI Studio](https://aistudio.google.com/app/apikey).
 
-## setting your PERPLEXITY_API_KEY API key
- 
- Define the  "PERPLEXITY_API_KEY" environment variable with the value of your Perplexity API key
+## Dependencies
 
-## Examples:
+This library depends on:
+- `uiop`
+- `cl-json`
+- `dexador`
+- `alexandria`
+- `fiveam` (for tests)
 
-```lisp
-(gemini:generate "In one sentence, explain how AI works to a child.")
+Ensure these are available in your Quicklisp local-projects or via ASDF.
+
+## Usage
+
+Load the library using Quicklisp or ASDF:
+```common-lisp
+(ql:quickload :gemini)
+;; or
+(asdf:load-system :gemini)
 ```
+
+### Basic Generation
+
+To generate text from a prompt:
+```common-lisp
+(gemini:generate "gemini-1.5-flash-latest" "In one sentence, explain how AI works to a child.")
+;; => "AI is like a super smart computer brain that learns from information to answer questions and do tasks."
+```
+You can use other models like `"gemini-1.5-pro-latest"` as the first argument.
+
+### Counting Tokens
+
+To count the number of tokens a prompt will consume for a specific model:
+```common-lisp
+(gemini:count-tokens "gemini-1.5-flash-latest" "How many tokens is this sentence?")
+;; => 8 (example output, actual may vary)
+```
+
+### Chat Conversations
+
+To have a conversation with the model, provide a list of messages. Each message is a hash-table with a "role" ("user" or "model") and "text".
+```common-lisp
+(let ((chat-history (list
+                      (alexandria:plist-hash-table '("role" "user" "text" "What is the capital of France?"))
+                      (alexandria:plist-hash-table '("role" "model" "text" "The capital of France is Paris.")))))
+  ;; Add a new user message to the history
+  (push (alexandria:plist-hash-table '("role" "user" "text" "What is a famous landmark there?")) chat-history)
+  ;; Get the model's response (note: chat-history is now newest-first, the API expects oldest-first,
+  ;; but the current send-chat-message implementation in this library does not reverse it.
+  ;; For correct multi-turn, the application should manage message order before passing to send-chat-message,
+  ;; or the library function should be updated to handle it.)
+  (gemini:send-chat-message "gemini-1.5-flash-latest" (reverse chat-history)))
+;; => "A famous landmark in Paris is the Eiffel Tower." (example output)
+```
+*(Note: The example above uses `plist-hash-table` from `alexandria` for convenience in creating hash tables. Ensure your messages are correctly ordered for multi-turn conversations as per API requirements.)*
+
+### Streaming Generation
+
+For long generations, or to display text as it arrives, you can stream the response:
+```common-lisp
+(gemini:generate-streaming
+ "gemini-1.5-flash-latest"
+ "Tell me a short story about a brave Lisp macro."
+ (lambda (text-chunk)
+   (format t "~A" text-chunk)
+   (force-output)))
+;; This will print the story chunk by chunk as it's generated.
+;; The function itself returns T upon completion.
+```
+
+## Available Functions
+
+- `(gemini:generate model-id prompt)`: Generates text from a prompt using the specified model.
+- `(gemini:count-tokens model-id prompt)`: Counts the tokens for a given prompt and model.
+- `(gemini:send-chat-message model-id messages)`: Sends a chat history and gets a response from the model. `messages` should be a list of hash-tables, each specifying "role" and "text".
+- `(gemini:generate-streaming model-id prompt callback-function)`: Generates text, streaming chunks to the `callback-function`.
+
+## Running Tests
+
+The library uses the FiveAM testing framework. To run the tests:
+```common-lisp
+(asdf:test-system :gemini)
+```
+This will execute the test suite defined in `tests/test-gemini.lisp`, which includes mocked API calls.
+
+## Original Project Information
+
+The original project from which this was adapted can be found in the repository https://github.com/mark-watson/loving-common-lisp. The `Makefile` mentioned in the original README for fetching library examples is specific to that book's comprehensive collection of projects. This current library is a focused adaptation for Gemini.

--- a/gemini.asd
+++ b/gemini.asd
@@ -4,6 +4,8 @@
   :description "Library for using the perplexity search+LLM APIs"
   :author "Mark Watson"
   :license "Apache 2"
-  :depends-on (#:uiop #:cl-json #:dexador)
+  :depends-on (#:uiop #:cl-json #:dexador #:alexandria #:fiveam) ; Added fiveam
   :components ((:file "package")
-               (:file "gemini")))
+               (:file "gemini")
+               (:file "tests/test-gemini")) ; Added test file
+  :perform (asdf:test-op (op c) (fiveam:run! 'gemini-tests::gemini-suite))) ; Added test operation

--- a/gemini.lisp
+++ b/gemini.lisp
@@ -2,10 +2,14 @@
 
 (defvar *google-api-key* (uiop:getenv "GOOGLE_API_KEY"))
 (defvar
-  *gemini-api-url*
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent")
+  *gemini-api-base-url*
+  "https://generativelanguage.googleapis.com/v1beta/models/")
 
-(defun generate (prompt)
+(defun generate (model-id prompt)
+  "Generates text from a given prompt using the specified model.
+MODEL-ID: The ID of the model to use (e.g., \"gemini-1.5-pro-latest\", \"gemini-1.5-flash-latest\").
+PROMPT: The text prompt to generate content from.
+Returns the generated text as a string."
   (let* ((payload (make-hash-table :test 'equal)))
     (setf (gethash "contents" payload)
           (list (let ((contents (make-hash-table :test 'equal)))
@@ -14,8 +18,9 @@
                                 (setf (gethash "text" part) prompt)
                                 part)))
                   contents)))
-    (let* ((data (cl-json:encode-json-to-string payload))
-           (response (dex:post *gemini-api-url*
+    (let* ((api-url (concatenate 'string *gemini-api-base-url* model-id ":generateContent"))
+           (data (cl-json:encode-json-to-string payload))
+           (response (dex:post api-url
                                :headers `(("Content-Type" . "application/json")
                                           ("x-goog-api-key" . ,*google-api-key*))
                                :content data))
@@ -35,5 +40,123 @@
            (text (cdr text-pair)))
        text)))
 
-;; (gemini:generate "In one sentence, explain how AI works to a child.")
-;; (gemini:generate "Write a short, four-line poem about coding in Python.")
+(defun generate-streaming (model-id prompt callback)
+  "Generates text from a prompt using the specified model, streaming the response.
+MODEL-ID: The ID of the model to use (e.g., \"gemini-1.5-pro-latest\", \"gemini-1.5-flash-latest\").
+PROMPT: The text prompt to generate content from.
+CALLBACK: A function that will be called with each chunk of generated text as it arrives.
+Returns T to indicate completion, as text is handled by the callback."
+  (let* ((api-url (concatenate 'string *gemini-api-base-url* model-id ":streamGenerateContent"))
+         (payload (make-hash-table :test 'equal)))
+    (setf (gethash "contents" payload)
+          (list (let ((contents (make-hash-table :test 'equal)))
+                  (setf (gethash "parts" contents)
+                        (list (let ((part (make-hash-table :test 'equal)))
+                                (setf (gethash "text" part) prompt)
+                                part)))
+                  contents)))
+    (let* ((data (cl-json:encode-json-to-string payload))
+           (stream (dex:post api-url
+                             :headers `(("Content-Type" . "application/json")
+                                        ("x-goog-api-key" . ,*google-api-key*))
+                             :content data
+                             :want-stream t)))
+      (unwind-protect
+           (loop for line = (read-line stream nil nil)
+                 while line
+                 do
+                    (when (alexandria:starts-with-subseq "data: " line)
+                      (let* ((json-string (subseq line 6)) ;; Skip "data: "
+                             (decoded-chunk (ignore-errors (cl-json:decode-json-from-string json-string))))
+                        (when (and decoded-chunk (listp decoded-chunk)) ; Check if it's a valid alist
+                          (let* ((candidates-pair (assoc :CANDIDATES decoded-chunk))
+                                 (candidates (and candidates-pair (cdr candidates-pair)))
+                                 (candidate (and candidates (first candidates)))
+                                 (content-pair (and candidate (assoc :CONTENT candidate)))
+                                 (content (and content-pair (cdr content-pair)))
+                                 (parts-pair (and content (assoc :PARTS content)))
+                                 (parts (and parts-pair (cdr parts-pair)))
+                                 (first-part (and parts (first parts)))
+                                 (text-pair (and first-part (assoc :TEXT first-part)))
+                                 (text (and text-pair (cdr text-pair))))
+                            (when text
+                              (funcall callback text)))))))
+        (close stream))
+      t))) ; Indicate completion
+
+;; (gemini:generate "gemini-1.5-flash-latest" "In one sentence, explain how AI works to a child.")
+;; (gemini:generate "gemini-1.5-flash-latest" "Write a short, four-line poem about coding in Python.")
+
+(defun count-tokens (model-id prompt)
+  "Counts the number of tokens for a given prompt and model.
+MODEL-ID: The ID of the model to use (e.g., \"gemini-1.5-pro-latest\", \"gemini-1.5-flash-latest\").
+PROMPT: The text prompt to count tokens for.
+Returns the total token count as an integer."
+  (let* ((api-url (concatenate 'string *gemini-api-base-url* model-id ":countTokens"))
+         (payload (make-hash-table :test 'equal)))
+    ;; Construct payload similar to generate function
+    (setf (gethash "contents" payload)
+          (list (let ((contents (make-hash-table :test 'equal)))
+                  (setf (gethash "parts" contents)
+                        (list (let ((part (make-hash-table :test 'equal)))
+                                (setf (gethash "text" part) prompt)
+                                part)))
+                  contents)))
+    (let* ((data (cl-json:encode-json-to-string payload))
+           (response (dex:post api-url
+                               :headers `(("Content-Type" . "application/json")
+                                          ("x-goog-api-key" . ,*google-api-key*))
+                               :content data))
+           (response-string (if (stringp response)
+                                response
+                                (flex:octets-to-string response :external-format :utf-8)))
+           (decoded-response (cl-json:decode-json-from-string response-string))
+           ;; cl-json by default uses :UPCASE for keys, so :TOTAL-TOKENS should be correct
+           (total-tokens-pair (assoc :TOTAL-TOKENS decoded-response)))
+      (if total-tokens-pair
+          (cdr total-tokens-pair)
+          (error "Could not retrieve token count from API response: ~S" decoded-response)))))
+
+(defun send-chat-message (model-id messages)
+  "Sends a series of messages as a chat history and gets a response from the specified model.
+MODEL-ID: The ID of the model to use (e.g., \"gemini-1.5-pro-latest\", \"gemini-1.5-flash-latest\").
+MESSAGES: A list of hash-tables, where each hash-table must have a \"role\" (string: \"user\" or \"model\")
+          and a \"text\" (string: the message content).
+          Example: (list (alexandria:plist-hash-table '(\"role\" \"user\" \"text\" \"Hello!\"))
+                         (alexandria:plist-hash-table '(\"role\" \"model\" \"text\" \"Hi there!\")))
+Returns the model's response text as a string."
+  (let* ((api-url (concatenate 'string *gemini-api-base-url* model-id ":generateContent"))
+         (payload (make-hash-table :test 'equal))
+         (api-contents (mapcar (lambda (msg)
+                                 (let ((content-ht (make-hash-table :test 'equal)))
+                                   (setf (gethash "role" content-ht) (gethash "role" msg))
+                                   (setf (gethash "parts" content-ht)
+                                         (list (let ((part-ht (make-hash-table :test 'equal)))
+                                                 (setf (gethash "text" part-ht) (gethash "text" msg))
+                                                 part-ht)))
+                                   content-ht))
+                               messages)))
+    (setf (gethash "contents" payload) api-contents)
+    ;; The rest is similar to the 'generate' function:
+    ;; encode payload, make dex:post request, decode response, extract text
+    (let* ((data (cl-json:encode-json-to-string payload))
+           (response (dex:post api-url
+                               :headers `(("Content-Type" . "application/json")
+                                          ("x-goog-api-key" . ,*google-api-key*))
+                               :content data))
+           (response-string (if (stringp response)
+                                response
+                                (flex:octets-to-string response :external-format :utf-8)))
+           (decoded-response (cl-json:decode-json-from-string response-string))
+           ;; Standard response extraction logic from 'generate'
+           (candidates-pair (assoc :CANDIDATES decoded-response))
+           (candidates (cdr candidates-pair))
+           (candidate (first candidates))
+           (content-pair (assoc :CONTENT candidate))
+           (content (cdr content-pair))
+           (parts-pair (assoc :PARTS content))
+           (parts (cdr parts-pair))
+           (first-part (first parts))
+           (text-pair (assoc :TEXT first-part))
+           (text (cdr text-pair)))
+       text)))

--- a/package.lisp
+++ b/package.lisp
@@ -4,4 +4,4 @@
   (:use #:cl)
   (:import-from #:dexador
                 #:post)  ; Only import the symbols we need
-  (:export #:generate))
+  (:export #:generate #:count-tokens #:send-chat-message #:generate-streaming))

--- a/tests/test-gemini.lisp
+++ b/tests/test-gemini.lisp
@@ -1,0 +1,90 @@
+(defpackage #:gemini-tests
+  (:use #:cl #:fiveam #:gemini)
+  (:import-from #:dexador #:post) ; Import to be able to redefine it
+  (:import-from #:flexi-streams #:make-in-memory-input-stream #:string-to-octets)
+  (:import-from #:alexandria #:plist-hash-table #:starts-with-subseq))
+
+(in-package #:gemini-tests)
+
+;;; Global test state
+(def-suite gemini-suite :description "Test suite for Gemini API client.")
+(in-suite gemini-suite)
+
+;; Set a dummy API key for all tests
+(defvar gemini::*google-api-key* "dummy-test-key")
+
+;; Mocking infrastructure for dexador:post
+(defvar *mock-dex-post-handler* nil "Holds the current mock handler for dex:post.")
+(defvar *original-dex-post* #'dexador:post "To store the original dexador:post function.")
+
+;; Redefine dexador:post for testing purposes.
+;; This definition will be active when the tests are loaded and run.
+(defun dexador:post (url &key headers content want-stream)
+  (if *mock-dex-post-handler*
+      (funcall *mock-dex-post-handler* url :headers headers :content content :want-stream want-stream)
+      (error "dexador:post call not mocked! URL: ~A. Current handler: ~S" url *mock-dex-post-handler*)))
+
+;;; Tests
+
+(test generate-success
+  (let ((*mock-dex-post-handler*
+          (lambda (url &key headers content want-stream)
+            (declare (ignore headers content want-stream))
+            (is (string-equal url "https://generativelanguage.googleapis.com/v1beta/models/test-model:generateContent"))
+            "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Mocked response text\"}]}}]}")))
+    (is (string= (gemini:generate "test-model" "A prompt") "Mocked response text"))))
+
+(test count-tokens-success
+  (let ((*mock-dex-post-handler*
+          (lambda (url &key headers content want-stream)
+            (declare (ignore headers content want-stream))
+            (is (string-equal url "https://generativelanguage.googleapis.com/v1beta/models/test-model:countTokens"))
+            "{\"totalTokens\": 123}")))
+    (is (= (gemini:count-tokens "test-model" "A prompt") 123))))
+
+(test send-chat-message-success
+  (let ((*mock-dex-post-handler*
+          (lambda (url &key headers content want-stream)
+            (declare (ignore headers want-stream))
+            (is (string-equal url "https://generativelanguage.googleapis.com/v1beta/models/chat-model:generateContent"))
+            ;; Check that the content has the correct structure for chat
+            (let ((json-payload (cl-json:decode-json-from-string content)))
+              (is (equalp (gethash "role" (first (cdr (assoc :CONTENTS json-payload)))) "user"))
+              (is (equalp (gethash "text" (first (cdr (assoc :PARTS (first (cdr (assoc :CONTENTS json-payload))))))) "Hello")))
+            "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Mocked chat response\"}]}}]}")))
+    (let ((messages (list (alexandria:plist-hash-table '("role" "user" "text" "Hello") :test 'equal))))
+      (is (string= (gemini:send-chat-message "chat-model" messages) "Mocked chat response")))))
+
+(test generate-streaming-success
+  (let* ((accumulated-text (make-string-output-stream))
+         (*mock-dex-post-handler*
+           (lambda (url &key headers content want-stream)
+             (declare (ignore headers content))
+             (is (string-equal url "https://generativelanguage.googleapis.com/v1beta/models/stream-model:streamGenerateContent"))
+             (is want-stream) ; Ensure streaming is requested
+             ;; Simulate SSE stream
+             (let* ((sse-data1 "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Stream chunk 1 \"}]}}]}\n\n")
+                    (sse-data2 "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Stream chunk 2\"}]}}]}\n\n")
+                    (full-sse-response (concatenate 'string sse-data1 sse-data2)))
+               (flexi-streams:make-in-memory-input-stream (flexi-streams:string-to-octets full-sse-response :external-format :utf-8))))))
+    (let ((result (gemini:generate-streaming "stream-model" "A streaming prompt"
+                                            (lambda (text-chunk)
+                                              (write-string text-chunk accumulated-text)))))
+      (is-true result) ; Function should return T on completion
+      (is (string= (get-output-stream-string accumulated-text) "Stream chunk 1 Stream chunk 2")))))
+
+;; To run from SLIME:
+;; (asdf:test-system :gemini)
+;; Or, load the file and run:
+;; (fiveam:run! 'gemini-suite)
+;; (fiveam:run! 'generate-success)
+;; (fiveam:run! 'count-tokens-success)
+;; (fiveam:run! 'send-chat-message-success)
+;; (fiveam:run! 'generate-streaming-success)
+
+;; Restore original dexador:post if tests are reloaded interactively (optional, good practice)
+;; This is tricky because this file will be reloaded by ASDF. A more robust solution
+;; would involve a test runner that sets up and tears down mocks.
+;; For this task, we assume ASDF handles loading once per test run.
+;; To manually restore if needed:
+;; (setf dexador:post *original-dex-post*)


### PR DESCRIPTION
Adds support for specifying Gemini models (1.5 Pro, 1.5 Flash) and implements several new API functionalities:

- `count-tokens`: Calculates the number of tokens for a given prompt.
- `send-chat-message`: Enables multi-turn chat conversations.
- `generate-streaming`: Provides streaming responses for text generation.

The existing `generate` function has been refactored to accept a `model-id`.

A comprehensive unit test suite (`tests/test-gemini.lisp`) using the FiveAM framework has been added. These tests utilize mocking for `dexador:post` to simulate API responses and ensure reliable testing without actual API calls.

Documentation (docstrings in `gemini.lisp` and `README.md`) has been updated to reflect these new features and usage. The `gemini.asd` file has been updated to include test dependencies and test execution commands.